### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v1.2.0
+
+- Set azuread to require version >= 1.3.0 and updated examples due to deprecated naming convention.
+- Added node_taints for additional node pools. To not use node_taints, please set to _null_ or an empty list

--- a/aks.tf
+++ b/aks.tf
@@ -103,6 +103,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional_cluster" {
   max_count           = each.value.max_count
 
   node_labels = each.value.node_labels
+  node_taints = each.value.node_taints != null ? each.value.node_taints : [""]
   tags        = each.value.tags
 
   # Various additional settings

--- a/examples/complex/main.tf
+++ b/examples/complex/main.tf
@@ -1,6 +1,6 @@
 module "kubernetes" {
   source  = "roberthstrand/kubernetes/azurerm"
-  version = "1.1.0"
+  version = "1.2.0"
 
   name           = "demo"
   resource_group = azurerm_resource_group.cluster.name
@@ -30,6 +30,7 @@ module "kubernetes" {
       enable_auto_scaling = false
       min_count           = null
       max_count           = null
+      node_taints         = []
       node_labels = {
         "type" = "burstable"
       }
@@ -45,10 +46,13 @@ module "kubernetes" {
       enable_auto_scaling = true
       min_count           = 2
       max_count           = 3
+      node_taints         = ["key=value:NoSchedule", "key=value:NoSchedule"]
+
       node_labels = {
         "type"      = "cpu-optimized"
         "autoscale" = "true"
       }
+
       tags = null
       additional_settings = {
         mode     = "System"

--- a/examples/complex/settings.tf
+++ b/examples/complex/settings.tf
@@ -4,7 +4,7 @@ terraform {
       version = "=2.40.0"
     }
     azuread = {
-      version = "=0.7.0"
+      version = "=1.3.0"
     }
   }
 }
@@ -40,5 +40,5 @@ resource "azurerm_subnet" "aks" {
 }
 
 data "azuread_groups" "admins" {
-  names = ["aks-admin"]
+  display_names = ["aks-admin"]
 }

--- a/examples/defaults/main.tf
+++ b/examples/defaults/main.tf
@@ -1,6 +1,6 @@
 module "kubernetes" {
   source  = "roberthstrand/kubernetes/azurerm"
-  version = "1.1.0"
+  version = "1.2.0"
 
   name           = "demo"
   resource_group = azurerm_resource_group.cluster.name

--- a/examples/defaults/settings.tf
+++ b/examples/defaults/settings.tf
@@ -4,7 +4,7 @@ terraform {
       version = "=2.40.0"
     }
     azuread = {
-      version = "=0.7.0"
+      version = "=1.3.0"
     }
   }
 }
@@ -38,5 +38,5 @@ resource "azurerm_subnet" "aks" {
 }
 
 data "azuread_groups" "admins" {
-  names = ["aks-admin"]
+  display_names = ["aks-admin"]
 }

--- a/examples/with-service-principal/main.tf
+++ b/examples/with-service-principal/main.tf
@@ -1,6 +1,6 @@
 module "kubernetes" {
   source  = "roberthstrand/kubernetes/azurerm"
-  version = "1.1.0"
+  version = "1.2.0"
 
   name           = "demo"
   resource_group = azurerm_resource_group.cluster.name

--- a/examples/with-service-principal/settings.tf
+++ b/examples/with-service-principal/settings.tf
@@ -4,7 +4,7 @@ terraform {
       version = "=2.40.0"
     }
     azuread = {
-      version = "=0.7.0"
+      version = "=1.3.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,9 @@ terraform {
     azurerm = {
       version = ">=2.40.0"
     }
+    azuread = {
+      version = ">=1.3.0"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">=1.13.3"

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,7 @@ variable "additional_node_pools" {
     min_count           = number
     max_count           = number
     node_labels         = map(string)
+    node_taints         = list(string)
     tags                = map(string)
     additional_settings = map(string)
   }))


### PR DESCRIPTION
- Set azuread to require version >= 1.3.0 and updated examples due to deprecated naming convention.
- Added node_taints for additional node pools. To not use node_taints, please set to _null_ or an empty list