### PR TITLE
Changed pod_cidr from /24 to a /16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# v1.2.0
+# v1.2.1
 
 - Set azuread to require version >= 1.3.0 and updated examples due to deprecated naming convention.
 - Added node_taints for additional node pools. To not use node_taints, please set to _null_ or an empty list
+- Updated the pod_cidr with a network mask that doesn't break using kubenet

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "outbound_type" {
 variable "pod_cidr" {
   type        = string
   description = "When using the kubenet network plugin, a CIDR needs to be set for pod IP addresses."
-  default     = "192.168.0.0/24"
+  default     = "192.168.0.0/16"
 }
 variable "service_cidr" {
   type        = string


### PR DESCRIPTION
Noticed that I had set the pod_cidr range to a default of 24-bit mask, which breaks the usage of kubenet. The mask needs to be of such a size so that one node can set off an entire 24-bit mask for itself.